### PR TITLE
Support other container orchestrators (like Podman)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,13 +18,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Start containers
-        run: make openresty-dev DOCKER_COMPOSE_EXEC_OPTIONS="-T"
+        run: make openresty-dev CONTAINER_ORCHESTRATOR_EXEC_OPTIONS="-T"
 
       - name: Run test-e2e-trace-context
-        run: make openresty-unit-test DOCKER_COMPOSE_EXEC_OPTIONS="-T"
+        run: make openresty-unit-test CONTAINER_ORCHESTRATOR_EXEC_OPTIONS="-T"
 
       - name: Run openresty-test-e2e-trace-context
-        run: make openresty-test-e2e-trace-context DOCKER_COMPOSE_EXEC_OPTIONS="-T"
+        run: make openresty-test-e2e-trace-context CONTAINER_ORCHESTRATOR_EXEC_OPTIONS="-T"
 
       - name: Run openresty-test-e2e
-        run: make openresty-test-e2e DOCKER_COMPOSE_EXEC_OPTIONS="-T"
+        run: make openresty-test-e2e CONTAINER_ORCHESTRATOR_EXEC_OPTIONS="-T"

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
-DOCKER_COMPOSE_EXEC_OPTIONS := $(DOCKER_COMPOSE_EXEC_OPTIONS)
+CONTAINER_ORCHESTRATOR ?= docker-compose
+CONTAINER_ORCHESTRATOR_EXEC_OPTIONS := $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS)
 
 openresty-dev:
-	docker-compose up -d openresty
-	docker-compose exec $(DOCKER_COMPOSE_EXEC_OPTIONS) -- openresty bash -c 'cd /opt/opentelemetry-lua && luarocks make && nginx -s reload'
+	$(CONTAINER_ORCHESTRATOR) up -d openresty
+	$(CONTAINER_ORCHESTRATOR) exec $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS) -- openresty bash -c 'cd /opt/opentelemetry-lua && luarocks make && nginx -s reload'
 
 openresty-test-e2e:
-	docker-compose run -e PROXY_ENDPOINT=http://openresty/test/e2e --use-aliases --rm test-client
+	$(CONTAINER_ORCHESTRATOR) run -e PROXY_ENDPOINT=http://openresty/test/e2e --use-aliases --rm test-client
 
 openresty-test-e2e-trace-context:
-	docker-compose exec $(DOCKER_COMPOSE_EXEC_OPTIONS) -- openresty bash /opt/opentelemetry-lua/e2e-trace-context.sh
+	$(CONTAINER_ORCHESTRATOR) exec $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS) -- openresty bash /opt/opentelemetry-lua/e2e-trace-context.sh
 
 openresty-unit-test:
-	docker-compose exec $(DOCKER_COMPOSE_EXEC_OPTIONS) -- openresty bash -c 'cd /opt/opentelemetry-lua && prove -r'
+	$(CONTAINER_ORCHESTRATOR) exec $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS) -- openresty bash -c 'cd /opt/opentelemetry-lua && prove -r'
+
+openresty-build:
+	$(CONTAINER_ORCHESTRATOR) build

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ git clone this project, then run `luarocks make` in  project root directory.
 
 # Develop
 
-- set up environment: `make openresty-dev`
+- set up environment: `make openresty-build && make openresty-dev`
 - test e2e: `make openresty-test-e2e`
 - test trace context: `openresty-test-e2e-trace-context`
 - run unit test: `make openresty-unit-test`


### PR DESCRIPTION
Hi! Thanks so much for your work with this library 🙏

I use `podman-compose` instead of `docker-compose`. This PR makes that possible in this repo. It does the following:

1. Allows the user to specify a container orchestrator by passing `CONTAINER_ORCHESTRATOR` to `make` (`make openresty-dev CONTAINER_ORCHESTRATOR=podman`).
2. Defaults the value of `CONTAINER_ORCHESTRATOR` to `docker-compose` to preserve existing behavior.
3. Adds `make openresty-build` to build container images specified in `docker-compose.yml`.
4. Updates README to indicate that people should run `make openresty-build` before `make openresty-dev`.
5. Renames `DOCKER_COMPOSE_EXEC_OPTIONS` to `CONTAINER_ORCHESTRATOR_EXEC_OPTIONS`