### PR TITLE
Add .vscode directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+.vscode
 t/servroot


### PR DESCRIPTION
Some contributors may use [VSCode](https://code.visualstudio.com/), which may store files in the `.vscode` directory. This PR adds it to `.gitignore` to improve developer experience.