### PR TITLE
Check for timeval before trying to define

### DIFF
--- a/lib/opentelemetry/util.lua
+++ b/lib/opentelemetry/util.lua
@@ -6,13 +6,16 @@ local function ngx_time_nano()
 end
 
 local ffi = require("ffi")
+if not pcall(function() ffi.sizeof("timeval") end) then
+  ffi.cdef [[
+    typedef struct timeval {
+      long tv_sec;
+      long tv_usec;
+    } timeval;
+  ]]
+end
 
-ffi.cdef[[
-  typedef struct timeval {
-    long tv_sec;
-    long tv_usec;
-  } timeval;
-
+ffi.cdef [[
   int gettimeofday(struct timeval* t, void* tzp);
 ]]
 


### PR DESCRIPTION
If someone has already defined `timeval` using `ffi`, then they will see this error from this library: `error loading plugin: /usr/local/lib/lua/opentelemetry/util.lua:17: attempt to redefine 'timeval'.

This PR updates the code to check for `timeval` before defining it.