### PR TITLE
Use lua-resty-http instead of api7-lua-resty-http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.19.9.1-centos7
 
 RUN yum install -y gcc
-RUN luarocks install lua-resty-http 0.2.0
+RUN luarocks install lua-resty-http 0.16.1-0
 RUN luarocks install lua-protobuf 0.3.3
 RUN luarocks install busted 2.0.0-1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:1.19.9.1-centos7
 
 RUN yum install -y gcc
-RUN luarocks install api7-lua-resty-http 0.2.0
+RUN luarocks install lua-resty-http 0.2.0
 RUN luarocks install lua-protobuf 0.3.3
 RUN luarocks install busted 2.0.0-1
 

--- a/rockspec/opentelemetry-lua-master-0.rockspec
+++ b/rockspec/opentelemetry-lua-master-0.rockspec
@@ -13,7 +13,7 @@ description = {
 
 dependencies = {
     "lua-protobuf = 0.3.3",
-    "lua-resty-http = 0.2.0",
+    "lua-resty-http = 0.16.1-0",
 }
 
 build = {

--- a/rockspec/opentelemetry-lua-master-0.rockspec
+++ b/rockspec/opentelemetry-lua-master-0.rockspec
@@ -13,7 +13,7 @@ description = {
 
 dependencies = {
     "lua-protobuf = 0.3.3",
-    "api7-lua-resty-http = 0.2.0",
+    "lua-resty-http = 0.2.0",
 }
 
 build = {


### PR DESCRIPTION
I don't know if there are any api changes between the two http libraries. Will see if tests pass/fail.

Closes #14 