### PR TITLE
Add on_start hook to recording_span.new

### DIFF
--- a/lib/opentelemetry/trace/batch_span_processor.lua
+++ b/lib/opentelemetry/trace/batch_span_processor.lua
@@ -120,6 +120,10 @@ function _M.new(exporter, opts)
     return setmetatable(self, mt)
 end
 
+-- No-op for this span processor.
+function _M.on_start(self, span)
+end
+
 function _M.on_end(self, span)
     if not span.ctx:is_sampled() or self.closed then
         return

--- a/lib/opentelemetry/trace/recording_span.lua
+++ b/lib/opentelemetry/trace/recording_span.lua
@@ -35,7 +35,13 @@ function _M.new(tracer, parent_ctx, ctx, name, config)
         attributes = config.attributes or {},
         events = {},
     }
-    return setmetatable(self, mt)
+    local span = setmetatable(self, mt)
+
+    for _, sp in tracer.provider.span_processors do
+        sp:on_start(span)
+    end
+
+    return span
 end
 
 function _M.context(self)


### PR DESCRIPTION
Per the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onstart), the SDK should call the configured span processors' `on_start` hook when the span is started.