### PR TITLE
Remove unnecessary keepalive

### DIFF
--- a/lib/opentelemetry/trace/exporter/http_client.lua
+++ b/lib/opentelemetry/trace/exporter/http_client.lua
@@ -48,11 +48,6 @@ function _M.do_request(self, body)
         httpc:close()
         return
     end
-
-    local ok, err = httpc:set_keepalive(60000, 1)
-    if not ok then
-        ngx.log(ngx.ERR, "failed to set keepalive: ", err)
-    end
 end
 
 return _M


### PR DESCRIPTION
This PR removes an unnecessary `keepalive` call Why is it unnecessary? `http_client` calls [httpc:request_uri](https://github.com/yangxikun/opentelemetry-lua/blob/d92bb17c8514f6f73264d461d97a04e91f2aced7/lib/opentelemetry/trace/exporter/http_client.lua#L34), which [calls `:keepalive` by default](https://github.com/ledgetech/lua-resty-http#request_uri) ([code](https://github.com/ledgetech/lua-resty-http/blob/master/lib/resty/http.lua#L946-L958)).

