### PR TITLE
Return microseconds from gettimeofday

### DIFF
--- a/lib/opentelemetry/util.lua
+++ b/lib/opentelemetry/util.lua
@@ -20,6 +20,7 @@ ffi.cdef [[
 ]]
 
 local gettimeofday_struct = ffi.new("timeval")
+
 --------------------------------------------------------------------------------
 -- Return current time in microseconds (via FFI call). This is the maximum
 -- precision available from Linux's gettimeofday() function

--- a/lib/opentelemetry/util.lua
+++ b/lib/opentelemetry/util.lua
@@ -36,7 +36,7 @@ end
 _M.ngx_time_nano = ngx_time_nano
 _M.gettimeofday = ffi_gettimeofday
 
--- Return current time in milliseconds nanoseconds (there are 1000 nanoseconds
+-- Return current time in nanoseconds (there are 1000 nanoseconds
 -- in a microsecond)
 --
 -- @return current time in nanoseconds

--- a/lib/opentelemetry/util.lua
+++ b/lib/opentelemetry/util.lua
@@ -20,10 +20,16 @@ ffi.cdef [[
 ]]
 
 local gettimeofday_struct = ffi.new("timeval")
+--------------------------------------------------------------------------------
+-- Return current time in microseconds (via FFI call). This is the maximum
+-- precision available from Linux's gettimeofday() function
+--
+-- @return current time in microseconds
+--------------------------------------------------------------------------------
 local function ffi_gettimeofday()
     ffi.C.gettimeofday(gettimeofday_struct, nil)
-    return tonumber(gettimeofday_struct.tv_sec) * 1000000000 +
-            tonumber(gettimeofday_struct.tv_usec) * 1000
+    return tonumber(gettimeofday_struct.tv_sec) * 1000000 +
+            tonumber(gettimeofday_struct.tv_usec)
 end
 
 _M.ngx_time_nano = ngx_time_nano

--- a/lib/opentelemetry/util.lua
+++ b/lib/opentelemetry/util.lua
@@ -35,8 +35,17 @@ end
 _M.ngx_time_nano = ngx_time_nano
 _M.gettimeofday = ffi_gettimeofday
 
+-- Return current time in milliseconds nanoseconds (there are 1000 nanoseconds
+-- in a microsecond)
+--
+-- @return current time in nanoseconds
+--------------------------------------------------------------------------------
+local function gettimeofday_ns()
+    return ffi_gettimeofday() * 1000
+end
+
 -- default time function, will be used in this SDK
 -- change it if needed
-_M.time_nano = ffi_gettimeofday
+_M.time_nano = gettimeofday_ns
 
 return _M


### PR DESCRIPTION
[Linux's `gettimeofday` function](https://man7.org/linux/man-pages/man2/gettimeofday.2.html) uses a `timeval` struct which reports seconds and microseconds

```c
           struct timeval {
               time_t      tv_sec;     /* seconds */
               suseconds_t tv_usec;    /* microseconds */
           };

```

This is the maximum available precision from that function.

This PR updates `ffi_gettimeofday` to return `microseconds`, then updates `_M.time_nano` to point to a function that calculates nanoseconds based on that.

I made this change because I found the code confusing, and also am working on using milliseconds in another PR.

Note: using nanoseconds makes it easier to deal with the [protos](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto#L158-L164), even though the library does have nanosecond precision on span timing.