### PR TITLE
Add exponential backoff for calls to collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ openresty-unit-test:
 	$(CONTAINER_ORCHESTRATOR) exec $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS) -- openresty bash -c 'cd /opt/opentelemetry-lua && prove -r'
 
 lua-unit-test:
-	$(CONTAINER_ORCHESTRATOR) run -e OTEL_LUA_RANDOMSEED=ostime $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS) -- openresty-test bash -c 'cd /opt/opentelemetry-lua && busted --lpath="./lib/?.lua;./lib/?/?.lua;./lib/?/init.lua"' .
+	$(CONTAINER_ORCHESTRATOR) run $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS) -- openresty-test bash -c 'cd /opt/opentelemetry-lua && ./busted-runner'
 
 openresty-build:
 	$(CONTAINER_ORCHESTRATOR) build

--- a/busted-runner
+++ b/busted-runner
@@ -4,6 +4,26 @@ package.path = './lib/?.lua;./lib/?/?.lua;./lib/?/init.lua' .. package.path
 
 _TEST = true
 
+-- Set up global tracer
+Global = require("opentelemetry.global")
+local tracer_provider = require("opentelemetry.trace.tracer_provider")
+local attr = require("opentelemetry.attribute")
+local resource = require("opentelemetry.resource")
+local always_on_sampler = require("opentelemetry.trace.sampling.always_on_sampler")
+local otlp_exporter = require("opentelemetry.trace.exporter.otlp")
+local http_client = require("opentelemetry.trace.exporter.http_client")
+local batch_span_processor = require("opentelemetry.trace.batch_span_processor")
+local client = http_client.new("127.0.0.1:4317", 3, {header_key = "header_val"})
+local exporter = otlp_exporter.new(client)
+local processor = batch_span_processor.new(exporter, {
+    drop_on_queue_full = false, max_queue_size = 1024, batch_timeout = 3, inactive_timeout = 1, max_export_batch_size = 10
+})
+local tracer_provider = tracer_provider.new(processor, {
+    sampler = always_on_sampler,
+    resource = resource.new(attr.string("service.name", "openresty"), attr.int("attr_int", 100)),
+})
+Global.set_tracer_provider(tracer_provider)
+
 if ngx ~= nil then
     ngx.exit = function() end
 end

--- a/busted-runner
+++ b/busted-runner
@@ -1,0 +1,16 @@
+#!/usr/bin/env resty
+
+package.path = './lib/?.lua;./lib/?/?.lua;./lib/?/init.lua' .. package.path
+
+_TEST = true
+
+if ngx ~= nil then
+    ngx.exit = function() end
+end
+
+-- Busted command-line runner
+require 'busted.runner' (
+    {
+        standalone = false,
+    }
+)

--- a/lib/opentelemetry/trace/exporter/http_client.lua
+++ b/lib/opentelemetry/trace/exporter/http_client.lua
@@ -46,7 +46,7 @@ function _M.do_request(self, body)
     if res.status ~= 200  then
         ngx.log(ngx.ERR, "request failed: ", res.body)
         httpc:close()
-        return nil, err
+        return nil, "request failed: " .. res.status
     end
 
     return res, nil

--- a/lib/opentelemetry/trace/exporter/http_client.lua
+++ b/lib/opentelemetry/trace/exporter/http_client.lua
@@ -40,14 +40,16 @@ function _M.do_request(self, body)
     if not res then
         ngx.log(ngx.ERR, "request failed: ", err)
         httpc:close()
-        return
+        return nil, err
     end
 
     if res.status ~= 200  then
         ngx.log(ngx.ERR, "request failed: ", res.body)
         httpc:close()
-        return
+        return nil, err
     end
+
+    return res, nil
 end
 
 return _M

--- a/lib/opentelemetry/trace/exporter/otlp.lua
+++ b/lib/opentelemetry/trace/exporter/otlp.lua
@@ -1,6 +1,6 @@
 local pb = require("opentelemetry.trace.exporter.pb")
 local util = require("opentelemetry.util")
-local RETRY_LIMIT = 5
+local RETRY_LIMIT = 3
 local DEFAULT_TIMEOUT_MS = 10000
 
 local _M = {
@@ -31,9 +31,7 @@ local function call_collector(exporter, pb_encoded_body)
         local res, _ = exporter.client:do_request(pb_encoded_body)
         if not res then
             failures = failures + 1
-            if not _TEST then
-                ngx.sleep(util.random_float(2 ^ failures))
-            end
+            ngx.sleep(util.random_float(2 ^ failures))
             ngx.log(ngx.INFO, "Retrying call to collector (retry #" .. failures .. ")")
         else
             break

--- a/lib/opentelemetry/trace/exporter/otlp.lua
+++ b/lib/opentelemetry/trace/exporter/otlp.lua
@@ -18,17 +18,17 @@ function _M.new(http_client, timeout_ms)
     return setmetatable(self, mt)
 end
 
-local function call_collector(self, pb_encoded_body)
+local function call_collector(exporter, pb_encoded_body)
     local start_time_ms = util.gettimeofday_ms()
     local failures = 0
 
     while failures < RETRY_LIMIT do
-        if util.gettimeofday_ms() - start_time_ms > self.timeout_ms then
-            ngx.log(ngx.WARN, "Collector retries timed out (timeout " .. self.timeout_ms .. ")")
+        if util.gettimeofday_ms() - start_time_ms > exporter.timeout_ms then
+            ngx.log(ngx.WARN, "Collector retries timed out (timeout " .. exporter.timeout_ms .. ")")
             break
         end
 
-        local res, _ = self.client:do_request(pb_encoded_body)
+        local res, _ = exporter.client:do_request(pb_encoded_body)
         if not res then
             failures = failures + 1
             if not _TEST then
@@ -91,7 +91,7 @@ function _M.export_spans(self, spans)
             status = span.status,
         })
     end
-    self:call_collector(pb.encode(body))
+    call_collector(self, pb.encode(body))
 end
 
 function _M.shutdown(self)

--- a/lib/opentelemetry/trace/exporter/otlp.lua
+++ b/lib/opentelemetry/trace/exporter/otlp.lua
@@ -96,8 +96,4 @@ function _M.shutdown(self)
 
 end
 
-if _TEST then
-    _M.call_collector = call_collector
-end
-
 return _M

--- a/lib/opentelemetry/trace/exporter/otlp.lua
+++ b/lib/opentelemetry/trace/exporter/otlp.lua
@@ -1,4 +1,7 @@
 local pb = require("opentelemetry.trace.exporter.pb")
+local util = require("opentelemetry.util")
+local RETRY_LIMIT = 5
+local DEFAULT_TIMEOUT_MS = 10000
 
 local _M = {
 }
@@ -7,11 +10,35 @@ local mt = {
     __index = _M
 }
 
-function _M.new(http_client)
+function _M.new(http_client, timeout_ms)
     local self = {
         client = http_client,
+        timeout_ms = timeout_ms or DEFAULT_TIMEOUT_MS,
     }
     return setmetatable(self, mt)
+end
+
+local function call_collector(self, pb_encoded_body)
+    local start_time_ms = util.gettimeofday_ms()
+    local failures = 0
+
+    while failures < RETRY_LIMIT do
+        if util.gettimeofday_ms() - start_time_ms > self.timeout_ms then
+            ngx.log(ngx.WARN, "Collector retries timed out (timeout " .. self.timeout_ms .. ")")
+            break
+        end
+
+        local res, _ = self.client:do_request(pb_encoded_body)
+        if not res then
+            failures = failures + 1
+            if not _TEST then
+                ngx.sleep(util.random_float(2 ^ failures))
+            end
+            ngx.log(ngx.INFO, "Retrying call to collector (retry #" .. failures .. ")")
+        else
+            break
+        end
+    end
 end
 
 local function hex2bytes(str)
@@ -64,11 +91,15 @@ function _M.export_spans(self, spans)
             status = span.status,
         })
     end
-    self.client:do_request(pb.encode(body))
+    self:call_collector(pb.encode(body))
 end
 
 function _M.shutdown(self)
 
+end
+
+if _TEST then
+    _M.call_collector = call_collector
 end
 
 return _M

--- a/lib/opentelemetry/trace/id_generator.lua
+++ b/lib/opentelemetry/trace/id_generator.lua
@@ -1,16 +1,11 @@
+local util = require "opentelemetry.util"
 local bit = require 'bit'
 
 local tohex = bit.tohex
 local fmt = string.format
-local random = math.random
+local random = util.random
 
 local _M = {}
-
-if (os.getenv("OTEL_LUA_RANDOMSEED") == "ostime") then
-    math.randomseed(os.time(os.date("!*t")))
-else
-    math.randomseed(ngx.time() + ngx.worker.pid())
-end
 
 function _M.new_span_id()
     return fmt("%s%s%s%s%s%s%s%s",

--- a/spec/trace/exporter/otlp_spec.lua
+++ b/spec/trace/exporter/otlp_spec.lua
@@ -1,31 +1,50 @@
 local exporter = require "opentelemetry.trace.exporter.otlp"
 local client = require "opentelemetry.trace.exporter.http_client"
+local context_storage = require("opentelemetry.context_storage")
+local context = require "opentelemetry.context"
+local tp = Global.get_tracer_provider()
+local tracer = tp:tracer("test")
 
-describe("call_collector", function()
+describe("export_spans", function()
     it("invokes do_request when there are no failures", function()
+        local span
+        local ctx = context.new(context_storage)
+        ctx:attach()
+        ctx, span = tracer:start(ctx, "test span")
+        span:finish()
         local client = client.new("http://localhost:8080", 10)
         local cb = exporter.new(client)
         client.do_request = function() return "ok", nil end
         spy.on(client, "do_request")
-        cb:call_collector("ok")
-        assert.spy(client.do_request).was_called_with(client, "ok")
+        cb:export_spans({ span })
+        assert.spy(client.do_request).was_called_with(client, match.is_string())
     end)
 
     it("doesn't invoke protected_call when failures is equal to retry limit", function()
+        local span
+        local ctx = context.new(context_storage)
+        ctx:attach()
+        ctx, span = tracer:start(ctx, "test span")
+        span:finish()
         local client = client.new("http://localhost:8080", 10)
         local cb = exporter.new(client, 10000)
         client.do_request = function() return nil, "there was a problem" end
         spy.on(client, "do_request")
-        cb:call_collector("ok")
-        assert.spy(client.do_request).was_called(5)
+        cb:export_spans({ span })
+        assert.spy(client.do_request).was_called(3)
     end)
 
     it("doesn't invoke do_request when start time is more than timeout_ms ago", function()
+        local span
+        local ctx = context.new(context_storage)
+        ctx:attach()
+        ctx, span = tracer:start(ctx, "test span")
+        span:finish()
         local client = client.new("http://localhost:8080", 10)
         -- Set default timeout to -1, so that we're already over the timeout
         local cb = exporter.new(client, -1)
         spy.on(client, "do_request")
-        cb:call_collector("ok")
+        cb:export_spans({ span})
         assert.spy(client.do_request).was_not_called()
     end)
 end)

--- a/spec/trace/exporter/otlp_spec.lua
+++ b/spec/trace/exporter/otlp_spec.lua
@@ -1,0 +1,31 @@
+local exporter = require "opentelemetry.trace.exporter.otlp"
+local client = require "opentelemetry.trace.exporter.http_client"
+
+describe("call_collector", function()
+    it("invokes do_request when there are no failures", function()
+        local client = client.new("http://localhost:8080", 10)
+        local cb = exporter.new(client)
+        client.do_request = function() return "ok", nil end
+        spy.on(client, "do_request")
+        cb:call_collector("ok")
+        assert.spy(client.do_request).was_called_with(client, "ok")
+    end)
+
+    it("doesn't invoke protected_call when failures is equal to retry limit", function()
+        local client = client.new("http://localhost:8080", 10)
+        local cb = exporter.new(client, 10000)
+        client.do_request = function() return nil, "there was a problem" end
+        spy.on(client, "do_request")
+        cb:call_collector("ok")
+        assert.spy(client.do_request).was_called(5)
+    end)
+
+    it("doesn't invoke do_request when start time is more than timeout_ms ago", function()
+        local client = client.new("http://localhost:8080", 10)
+        -- Set default timeout to -1, so that we're already over the timeout
+        local cb = exporter.new(client, -1)
+        spy.on(client, "do_request")
+        cb:call_collector("ok")
+        assert.spy(client.do_request).was_not_called()
+    end)
+end)


### PR DESCRIPTION
Per the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#retry), SDKs' exporters should have a retry strategy with exponential backoff and jitter.

This PR:

- Adds retries and exponential backoff to otlp exporter
- Updates `util` to include a `gettimeofday_ms()` method
- Also includes changes from a [separate PR](https://github.com/yangxikun/opentelemetry-lua/pull/21)
- Adds a `busted` test harness, which runs specs in the `resty` context (which makes `ngx` variable access possible) 