### PR TITLE
allow semantic access to result enum values

### DIFF
--- a/lib/opentelemetry/trace/sampling/result.lua
+++ b/lib/opentelemetry/trace/sampling/result.lua
@@ -1,4 +1,7 @@
 local _M = {
+    drop = 0,
+    record_only = 1,
+    record_and_sample = 2
 }
 
 local mt = {
@@ -18,11 +21,11 @@ function _M.new(decision, trace_state)
 end
 
 function _M.is_sampled(self)
-    return self.decision == 2
+    return self.decision == self.record_and_sample
 end
 
 function _M.is_recording(self)
-    return self.decision == 1 or self.decision == 2
+    return self.decision == self.record_only or self.decision == self.record_and_sample
 end
 
 return _M


### PR DESCRIPTION
When working on a custom sampler, it is helpful to have access to the different values of the sampling decision enum.

This PR exports the different sampling decisions' integer mapping.