### PR TITLE
wrap context_storage in getter; fallback to empty context

### DIFF
--- a/lib/opentelemetry/context.lua
+++ b/lib/opentelemetry/context.lua
@@ -66,8 +66,11 @@ end
 -- @return            boolean, string
 --------------------------------------------------------------------------------
 function _M.current()
-    return otel_global.get_context_storage()[context_key] and
-        otel_global.get_context_storage()[context_key][#otel_global.get_context_storage()[context_key]]
+    if otel_global.get_context_storage()[context_key] then
+        return otel_global.get_context_storage()[context_key][#otel_global.get_context_storage()[context_key]]
+    else
+        return _M.new()
+    end
 end
 
 --------------------------------------------------------------------------------

--- a/lib/opentelemetry/context.lua
+++ b/lib/opentelemetry/context.lua
@@ -29,14 +29,14 @@ end
 -- @return              token to be used for detaching
 --------------------------------------------------------------------------------
 function _M.attach(self)
-    if otel_global.context_storage[context_key] then
-        table.insert(otel_global.context_storage[context_key], self)
+    if otel_global.get_context_storage()[context_key] then
+        table.insert(otel_global.get_context_storage()[context_key], self)
     else
-        otel_global.context_storage[context_key] = { self }
+        otel_global.get_context_storage()[context_key] = { self }
     end
 
     -- the length of the stack is token used to detach context
-    return #otel_global.context_storage[context_key]
+    return #otel_global.get_context_storage()[context_key]
 end
 
 --------------------------------------------------------------------------------
@@ -47,12 +47,12 @@ end
 -- @return            boolean, string
 --------------------------------------------------------------------------------
 function _M.detach(self, token)
-    if #otel_global.context_storage[context_key] == token then
-        table.remove(otel_global.context_storage[context_key])
+    if #otel_global.get_context_storage()[context_key] == token then
+        table.remove(otel_global.get_context_storage()[context_key])
         return true, nil
     else
         local error_message = "Token does not match (" ..
-            #otel_global.context_storage[context_key] ..
+            #otel_global.get_context_storage()[context_key] ..
             " context entries in stack, token provided was " .. token .. ")."
         ngx.log(ngx.WARN, error_message)
         return false, error_message
@@ -66,8 +66,8 @@ end
 -- @return            boolean, string
 --------------------------------------------------------------------------------
 function _M.current()
-    return otel_global.context_storage[context_key] and
-        otel_global.context_storage[context_key][#otel_global.context_storage[context_key]]
+    return otel_global.get_context_storage()[context_key] and
+        otel_global.get_context_storage()[context_key][#otel_global.get_context_storage()[context_key]]
 end
 
 --------------------------------------------------------------------------------

--- a/lib/opentelemetry/global.lua
+++ b/lib/opentelemetry/global.lua
@@ -1,4 +1,4 @@
-_M = { context_storage = ngx.ctx }
+_M = { context_storage = nil }
 
 function _M.set_tracer_provider(tp)
     _M.tracer_provider = tp
@@ -10,6 +10,10 @@ end
 
 function _M.tracer(name, opts)
     return _M.tracer_provider:tracer(name, opts)
+end
+
+function _M.get_context_storage()
+    return _M.context_storage or ngx.ctx
 end
 
 function _M.set_context_storage(context_storage)

--- a/t/context.t
+++ b/t/context.t
@@ -31,8 +31,8 @@ location = /t {
         local tracer_provider = require("opentelemetry.trace.tracer_provider").new()
         local tracer = tracer_provider:tracer("unit_test")
         local context, recording_span = tracer:start(context, "recording")
-        if context.current().sp ~= nil then
-            ngx.say("unexpected context.current()")
+        if context.current().sp:is_recording() ~= false then
+            ngx.say("expected context.current() span to be non-recording")
         end
         context:attach()
         if context.current():span().name ~= "recording" then

--- a/t/context.t
+++ b/t/context.t
@@ -31,7 +31,7 @@ location = /t {
         local tracer_provider = require("opentelemetry.trace.tracer_provider").new()
         local tracer = tracer_provider:tracer("unit_test")
         local context, recording_span = tracer:start(context, "recording")
-        if context.current() ~= nil then
+        if context.current().sp ~= nil then
             ngx.say("unexpected context.current()")
         end
         context:attach()


### PR DESCRIPTION
A couple follow-ups to #24:

- `ngx.ctx` was being invoked prior to `nginx.ctx` existing in openresty. We can solve this problem by wrapping the `context_storage` field in a getter.
- `context.current` was sometimes returned `nil`. I think it's nice to return an empty `context` so that users can rely on that API. 