### PR TITLE
Add metrics reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,23 @@ span:add_event(name, {attributes = {attr.string("type", "job")}})
 -- get tracer provider
 local tp = span:tracer_provider()
 ```
+
+### Metrics Reporting
+
+To gather metrics about the operation of this library, users can register a metrics reporter with the `opentelemetry.global` module. Your metrics reporter should satisfy the interface in `lib/opentelemetry/metrics_reporter.lua`. For example:
+
+```lua
+local otel_global = require("opentelemetry.global")
+local my_metrics_reporter = {
+    add_to_counter = function(self, metric, increment, labels)
+        print("make a metric call!")
+    end
+    record_value = function(self, metric, increment, labels)
+        print("make a metric call!")
+    end
+    observe_value = function(self, metric, increment, labels)
+        print("make a metric call!")
+    end
+}
+otel_global.set_metrics_reporter(metrics_reporter)
+```

--- a/lib/opentelemetry/global.lua
+++ b/lib/opentelemetry/global.lua
@@ -1,5 +1,6 @@
 local metrics_reporter = require("opentelemetry.metrics_reporter")
-_M = { context_storage = nil, metrics_reporter = metrics_reporter }
+
+local _M = { context_storage = nil, metrics_reporter = metrics_reporter }
 
 function _M.set_tracer_provider(tp)
     _M.tracer_provider = tp

--- a/lib/opentelemetry/global.lua
+++ b/lib/opentelemetry/global.lua
@@ -1,4 +1,5 @@
-_M = { context_storage = nil }
+local metrics_reporter = require("opentelemetry.metrics_reporter")
+_M = { context_storage = nil, metrics_reporter = metrics_reporter }
 
 function _M.set_tracer_provider(tp)
     _M.tracer_provider = tp
@@ -6,6 +7,10 @@ end
 
 function _M.get_tracer_provider()
     return _M.tracer_provider
+end
+
+function _M.set_metrics_reporter(metrics_reporter)
+    _M.metrics_reporter = metrics_reporter
 end
 
 function _M.tracer(name, opts)

--- a/lib/opentelemetry/metrics_reporter.lua
+++ b/lib/opentelemetry/metrics_reporter.lua
@@ -1,0 +1,48 @@
+--------------------------------------------------------------------------------
+-- This defines an interface used for reporting metrics. It defaults to a noop.
+-- Users can supply a module that satisfies this interface to actually generate
+-- metrics.
+--------------------------------------------------------------------------------
+
+local _M = {}
+
+--------------------------------------------------------------------------------
+-- Adds an increment to a metric with the provided labels. This should be used
+-- with counter metrics
+--
+-- @param metric The metric to increment
+-- @param increment The amount to increment the metric by
+-- @param labels The labels to use for the metric
+-- return nil
+--------------------------------------------------------------------------------
+function _M:add_to_counter(metric, increment, labels)
+    return nil
+end
+
+--------------------------------------------------------------------------------
+-- Record a value for metric with provided labels. This should be used with
+-- histogram or distribution metrics.
+--
+-- @param metric The metric to record a value for
+-- @param value The value to set for the metric
+-- @param labels The labels to use for the metric
+-- return nil
+--------------------------------------------------------------------------------
+function _M:record_value(metric, value, labels)
+    return nil
+end
+
+--------------------------------------------------------------------------------
+-- Observe a value for a metric with provided labels. This corresponds to the
+-- gauge metric type in datadog
+--
+-- @param metric The metric to record a value for
+-- @param value The value to set for the metric
+-- @param labels The labels to use for the metric
+-- return nil
+--------------------------------------------------------------------------------
+function _M:observe_value(metric, value, labels)
+    return nil
+end
+
+return _M

--- a/lib/opentelemetry/trace/batch_span_processor.lua
+++ b/lib/opentelemetry/trace/batch_span_processor.lua
@@ -162,6 +162,7 @@ function _M.on_end(self, span)
         end
 
         -- export spans
+        otel_global.metrics_reporter:observe_value(buffer_utilization_metric, self:get_queue_size()/ self.max_queue_size)
         process_batches_timer(self, self.batch_to_process)
         self.batch_to_process = {}
     end

--- a/lib/opentelemetry/trace/batch_span_processor.lua
+++ b/lib/opentelemetry/trace/batch_span_processor.lua
@@ -39,7 +39,6 @@ local function process_batches(premature, self, batches)
     if premature then
         return
     end
-    otel_global.metrics_reporter:observe_value(buffer_utilization_metric, #self.queue / self.max_queue_size)
 
     for _, batch in ipairs(batches) do
         otel_global.metrics_reporter:record_value(batch_size_metric, #batch)

--- a/lib/opentelemetry/trace/batch_span_processor.lua
+++ b/lib/opentelemetry/trace/batch_span_processor.lua
@@ -42,7 +42,7 @@ local function process_batches(premature, self, batches)
     otel_global.metrics_reporter:observe_value(buffer_utilization_metric, #self.queue / self.max_queue_size)
 
     for _, batch in ipairs(batches) do
-        otel_global.metrics_reporter:record_value(batch_size_metric, #batch, {})
+        otel_global.metrics_reporter:record_value(batch_size_metric, #batch)
         local success, err = self.exporter:export_spans(batch)
         report_result(success, err, #batch)
     end

--- a/lib/opentelemetry/trace/batch_span_processor.lua
+++ b/lib/opentelemetry/trace/batch_span_processor.lua
@@ -1,6 +1,13 @@
+local otel_global = require("opentelemetry.global")
 local timer_at = ngx.timer.at
 local now = ngx.now
 local create_timer
+local batch_size_metric = "otel.bsp.batch_size"
+local buffer_utilization_metric = "otel.bsp.buffer_utilization"
+local dropped_spans_metric = "otel.bsp.dropped_spans"
+local export_success_metric = "otel.bsp.export.success"
+local exported_spans_metric = "otel.bsp.exported_spans"
+local exporter_failure_metric = "otel.otlp_exporter.failure"
 
 local _M = {
 }
@@ -9,13 +16,35 @@ local mt = {
     __index = _M
 }
 
+local function report_dropped_spans(count, reason)
+    otel_global.metrics_reporter:add_to_counter(
+        dropped_spans_metric, count, { reason = reason })
+end
+
+local function report_result(success, err, batch_size)
+    if success then
+        otel_global.metrics_reporter:add_to_counter(
+            export_success_metric, 1)
+        otel_global.metrics_reporter:add_to_counter(
+            exported_spans_metric, batch_size)
+    else
+        err = err or "unknown"
+        otel_global.metrics_reporter:add_to_counter(
+            exporter_failure_metric, 1, { reason = err })
+        report_dropped_spans(batch_size, err)
+    end
+end
+
 local function process_batches(premature, self, batches)
     if premature then
         return
     end
+    otel_global.metrics_reporter:observe_value(buffer_utilization_metric, #self.queue / self.max_queue_size)
 
     for _, batch in ipairs(batches) do
-        self.exporter:export_spans(batch)
+        otel_global.metrics_reporter:record_value(batch_size_metric, #batch, {})
+        local success, err = self.exporter:export_spans(batch)
+        report_result(success, err, #batch)
     end
 end
 
@@ -129,7 +158,7 @@ function _M.on_end(self, span)
         -- drop span
         if self.drop_on_queue_full then
             ngx.log(ngx.WARN, "queue is full, drop span: trace_id = ", span.ctx.trace_id, " span_id = ", span.ctx.span_id)
-            self.dropping_count = self.dropping_count + 1
+            report_dropped_spans(1, "buffer-full")
             return
         end
 
@@ -186,10 +215,6 @@ end
 
 function _M.get_queue_size(self)
     return #self.queue + #self.batch_to_process * self.max_export_batch_size
-end
-
-function _M.get_dropping_count(self)
-    return self.dropping_count
 end
 
 return _M

--- a/lib/opentelemetry/trace/batch_span_processor.lua
+++ b/lib/opentelemetry/trace/batch_span_processor.lua
@@ -177,6 +177,7 @@ function _M.on_end(self, span)
     end
 
     if not self.is_timer_running then
+        otel_global.metrics_reporter:observe_value(buffer_utilization_metric, self:get_queue_size()/ self.max_queue_size)
         create_timer(self, self.inactive_timeout)
     end
 end

--- a/lib/opentelemetry/trace/exporter/otlp.lua
+++ b/lib/opentelemetry/trace/exporter/otlp.lua
@@ -1,8 +1,10 @@
 local encoder = require("opentelemetry.trace.exporter.encoder")
 local pb = require("opentelemetry.trace.exporter.pb")
+local otel_global = require("opentelemetry.global")
 local util = require("opentelemetry.util")
 local RETRY_LIMIT = 3
 local DEFAULT_TIMEOUT_MS = 10000
+local exporter_request_duration_metric = "otel.otlp_exporter.request_duration"
 
 local _M = {
 }
@@ -19,25 +21,42 @@ function _M.new(http_client, timeout_ms)
     return setmetatable(self, mt)
 end
 
+--------------------------------------------------------------------------------
+-- Repeatedly make calls to collector until success, failure threshold or
+-- timeout
+--
+-- @param exporter The exporter to use for the collector call
+-- @param pb_encoded_body protobuf-encoded body to send to the collector
+-- @return true if call succeeded; false if call failed
+-- @return nil if call succeeded; error message string if call failed
+--------------------------------------------------------------------------------
 local function call_collector(exporter, pb_encoded_body)
     local start_time_ms = util.gettimeofday_ms()
     local failures = 0
+    local res
+    local res_error
 
     while failures < RETRY_LIMIT do
         if util.gettimeofday_ms() - start_time_ms > exporter.timeout_ms then
-            ngx.log(ngx.WARN, "Collector retries timed out (timeout " .. exporter.timeout_ms .. ")")
-            break
+            local err_message = "Collector retries timed out (timeout " .. exporter.timeout_ms .. ")"
+            ngx.log(ngx.WARN, err_message)
+            return false, err_message
         end
 
-        local res, _ = exporter.client:do_request(pb_encoded_body)
+        local before_time = util.gettimeofday_ms()
+        res, res_error = exporter.client:do_request(pb_encoded_body)
+        local after_time = util.gettimeofday_ms()
+        otel_global.metrics_reporter:record_value(
+            exporter_request_duration_metric, after_time - before_time)
         if not res then
             failures = failures + 1
             ngx.sleep(util.random_float(2 ^ failures))
             ngx.log(ngx.INFO, "Retrying call to collector (retry #" .. failures .. ")")
         else
-            break
+            return true, nil
         end
     end
+    return false, res_error or "unknown"
 end
 
 function _M.export_spans(self, spans)
@@ -67,7 +86,7 @@ function _M.export_spans(self, spans)
             body.resource_spans[1].instrumentation_library_spans[1].spans,
             encoder.for_otlp(span))
     end
-    call_collector(self, pb.encode(body))
+    return call_collector(self, pb.encode(body))
 end
 
 function _M.shutdown(self)

--- a/rockspec/opentelemetry-lua-master-0.rockspec
+++ b/rockspec/opentelemetry-lua-master-0.rockspec
@@ -24,6 +24,7 @@ build = {
        ["opentelemetry.attribute"] = "lib/opentelemetry/attribute.lua",
        ["opentelemetry.instrumentation_library"] = "lib/opentelemetry/instrumentation_library.lua",
        ["opentelemetry.resource"] = "lib/opentelemetry/resource.lua",
+       ["opentelemetry.metrics_reporter"] = "lib/opentelemetry/metrics_reporter.lua",
        ["opentelemetry.trace.batch_span_processor"] = "lib/opentelemetry/trace/batch_span_processor.lua",
        ["opentelemetry.trace.event"] = "lib/opentelemetry/trace/event.lua",
        ["opentelemetry.trace.exporter.http_client"] = "lib/opentelemetry/trace/exporter/http_client.lua",


### PR DESCRIPTION
OpenTelemetry's Ruby SDK has a `MetricsReporter` class which can be used to send metrics about the export pipeline ([original pr](https://github.com/open-telemetry/opentelemetry-ruby/pull/510)). I think it would be useful in opentelemetry-lua so I have ported over the functionality.