### PR TITLE
Return unmodified context when traceparent header is absent

### DIFF
--- a/lib/opentelemetry/trace/propagation/text_map/trace_context_propagator.lua
+++ b/lib/opentelemetry/trace/propagation/text_map/trace_context_propagator.lua
@@ -194,7 +194,7 @@ function _M:extract(context, carrier, getter)
     getter = getter or self.text_map_getter
     local trace_id, span_id, trace_flags = parse_trace_parent(getter.get(carrier, traceparent_header))
     if not trace_id or not span_id or not trace_flags then
-        return context:with_span_context(empty_span_context)
+        return context
     end
 
     local trace_state = parse_trace_state(getter.get(carrier, tracestate_header))

--- a/spec/trace/propagation/text_map/trace_context_propagator_spec.lua
+++ b/spec/trace/propagation/text_map/trace_context_propagator_spec.lua
@@ -28,10 +28,10 @@ describe("text map propagator", function()
             local tracer_provider = tracer_provider.new()
             local tracer          = tracer_provider:tracer("test tracer")
             -- start a trace
-            local new_ctx = tracer:start(context, "span", { kind = 1 })
+            local new_ctx         = tracer:start(context, "span", { kind = 1 })
 
             -- figure out what traceheader should look like
-            local span_context= new_ctx.sp:context()
+            local span_context = new_ctx.sp:context()
             local traceparent = string.format("00-%s-%s-%02x",
                 span_context.trace_id, span_context.span_id, span_context.trace_flags)
 
@@ -43,11 +43,21 @@ describe("text map propagator", function()
     end)
 
     describe(":extract", function()
+        it("does not override existing context when none is present in traceparent", function()
+            local tmp      = text_map_propagator.new()
+            local old_ctx  = context.new()
+            local trace_id = "10f5b3bcfe3f0c2c5e1ef150fe0b5872"
+            local carrier  = newCarrier("nottraceparent", "doesn't matter")
+
+            local ctx = tmp:extract(old_ctx, carrier)
+            assert.are.same(ctx, old_ctx)
+        end)
+
         it("sets context when traceparent is valid", function()
-            local tmp             = text_map_propagator.new()
-            local context         = context.new()
-            local trace_id        = "10f5b3bcfe3f0c2c5e1ef150fe0b5872"
-            local carrier         = newCarrier("traceparent", string.format("00-%s-172accbce5f048db-01", trace_id))
+            local tmp      = text_map_propagator.new()
+            local context  = context.new()
+            local trace_id = "10f5b3bcfe3f0c2c5e1ef150fe0b5872"
+            local carrier  = newCarrier("traceparent", string.format("00-%s-172accbce5f048db-01", trace_id))
 
             local ctx = tmp:extract(context, carrier)
             assert.are.same(ctx.sp:context().trace_id, trace_id)


### PR DESCRIPTION
Fixes #34 