### PR TITLE
Allow user to specify end timestamp when finishing span

### DIFF
--- a/lib/opentelemetry/trace/non_recording_span.lua
+++ b/lib/opentelemetry/trace/non_recording_span.lua
@@ -27,7 +27,7 @@ end
 function _M.set_attributes()
 end
 
-function _M.finish()
+function _M.finish(_self, _end_timestamp)
 end
 
 function _M.record_error()

--- a/lib/opentelemetry/trace/noop_span.lua
+++ b/lib/opentelemetry/trace/noop_span.lua
@@ -17,7 +17,7 @@ end
 function _M.set_attributes()
 end
 
-function _M.finish()
+function _M.finish(_self, _end_timestamp)
 end
 
 function _M.record_error()

--- a/lib/opentelemetry/trace/recording_span.lua
+++ b/lib/opentelemetry/trace/recording_span.lua
@@ -80,14 +80,19 @@ function _M.set_attributes(self, ...)
 end
 
 ------------------------------------------------------------------
--- `end` is key word, so we use finish
+-- Finish the span. `end` is key word, so we use "finish."
+-- See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#end
+--
+-- @end_timestamp   end timestamp for span (nanoseconds). If not
+--                  supplied, span method will end at current
+--                  time.
 ------------------------------------------------------------------
-function _M.finish(self)
+function _M.finish(self, end_timestamp)
     if not self:is_recording() then
         return
     end
 
-    self.end_time = util.time_nano()
+    self.end_time = end_timestamp or util.time_nano()
     for _, sp in ipairs(self.tracer.provider.span_processors) do
         sp:on_end(self)
     end

--- a/t/trace/span_finish_timestamp.t
+++ b/t/trace/span_finish_timestamp.t
@@ -1,0 +1,32 @@
+use Test::Nginx::Socket 'no_plan';
+
+log_level('debug');
+repeat_each(1);
+no_long_string();
+no_root_location();
+run_tests();
+
+__DATA__
+
+=== TEST 1: span end timestamp can be set explicitly
+--- config
+location = /t {
+    content_by_lua_block {
+        local tracer_provider = require("opentelemetry.trace.tracer_provider").new()
+        local context = require("opentelemetry.context").new()
+        local span_context_new = require("opentelemetry.trace.span_context").new
+        local span_kind = require("opentelemetry.trace.span_kind")
+        local attr = require("opentelemetry.attribute")
+        local tracer = tracer_provider:tracer("unit_test")
+        local context, recording_span = tracer:start(context, "recording",
+            {kind = span_kind.producer, attributes = {attr.string("key", "value")}})
+        context.sp:finish(123456789)
+        if context.sp.end_time ~= 123456789 then
+            ngx.log(ngx.ERR, "end time should have been 123456789, was " .. context.sp.end_time)
+        end
+    }
+}
+--- request
+GET /t
+--- no_error_log
+123456789


### PR DESCRIPTION
The spec allows users to specify the time at which their spans end: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#end. This PR adds ability to do this in the library.