### PR TITLE
Check span id and trace id when checking span_context validity

### DIFF
--- a/lib/opentelemetry/trace/propagation/text_map/trace_context_propagator.lua
+++ b/lib/opentelemetry/trace/propagation/text_map/trace_context_propagator.lua
@@ -1,7 +1,6 @@
-local span_context_new = require("opentelemetry.trace.span_context").new
+local span_context = require("opentelemetry.trace.span_context")
 local text_map_getter = require("opentelemetry.trace.propagation.text_map.getter")
 local text_map_setter = require("opentelemetry.trace.propagation.text_map.setter")
-local empty_span_context = span_context_new()
 
 local _M = {
 }
@@ -15,8 +14,8 @@ local mt = {
 local traceparent_header = "traceparent"
 local tracestate_header  = "tracestate"
 
-local invalid_trace_id = '00000000000000000000000000000000'
-local invalid_span_id = '0000000000000000'
+local invalid_trace_id = span_context.INVALID_TRACE_ID
+local invalid_span_id = span_context.INVALID_SPAN_ID
 
 function _M.new()
     return setmetatable(
@@ -199,7 +198,7 @@ function _M:extract(context, carrier, getter)
 
     local trace_state = _M.parse_trace_state(getter.get(carrier, tracestate_header))
 
-    return context:with_span_context(span_context_new(trace_id, span_id, trace_flags, trace_state, true))
+    return context:with_span_context(span_context.new(trace_id, span_id, trace_flags, trace_state, true))
 end
 
 function _M.fields()

--- a/lib/opentelemetry/trace/span_context.lua
+++ b/lib/opentelemetry/trace/span_context.lua
@@ -1,4 +1,6 @@
 local _M = {
+    INVALID_TRACE_ID = "00000000000000000000000000000000",
+    INVALID_SPAN_ID = "0000000000000000"
 }
 
 local mt = {
@@ -7,17 +9,25 @@ local mt = {
 
 function _M.new(tid, sid, trace_flags, trace_state, remote)
     local self = {
-        trace_id = tid,
-        span_id  = sid,
+        trace_id    = tid,
+        span_id     = sid,
         trace_flags = trace_flags,
         trace_state = trace_state,
-        remote = remote,
+        remote      = remote,
     }
     return setmetatable(self, mt)
 end
 
 function _M.is_valid(self)
-    return self.trace_id and self.span_id
+    if self.trace_id == _M.INVALID_TRACE_ID or self.trace_id == nil then
+        return false
+    end
+
+    if self.span_id == _M.INVALID_SPAN_ID or self.span_id == nil then
+        return false
+    end
+
+    return true
 end
 
 function _M.is_remote(self)
@@ -30,11 +40,11 @@ end
 
 function _M.plain(self)
     return {
-        trace_id = self.trace_id,
-        span_id  = self.span_id,
+        trace_id    = self.trace_id,
+        span_id     = self.span_id,
         trace_flags = self.trace_flags,
         trace_state = self.trace_state,
-        remote = self.remote,
+        remote      = self.remote,
     }
 end
 

--- a/spec/trace/span_context_spec.lua
+++ b/spec/trace/span_context_spec.lua
@@ -1,0 +1,13 @@
+local span_context = require("opentelemetry.trace.span_context")
+
+describe("is_valid", function()
+    it("returns false when traceid == 00000000000000000000000000000000", function()
+        local sp_ctx = span_context.new("00000000000000000000000000000000", "1234567890123456", 1, nil, false)
+        assert.is_not_true(sp_ctx:is_valid())
+    end)
+
+    it("returns false when spanid == 0000000000000000", function()
+        local sp_ctx = span_context.new("00000000000000000000000000000001", "0000000000000000", 1, nil, false)
+        assert.is_not_true(sp_ctx:is_valid())
+    end)
+end)


### PR DESCRIPTION
Span contexts with trace id `00000000000000000000000000000000` or span id `0000000000000000` [are not valid](https://www.w3.org/TR/trace-context/#trace-id).