### PR TITLE
Copy current context entries in with_span

### DIFF
--- a/lib/opentelemetry/context.lua
+++ b/lib/opentelemetry/context.lua
@@ -116,7 +116,7 @@ function _M.extract_baggage(self)
 end
 
 function _M.with_span(self, span)
-    return self.new(self.entries or {}, span)
+    return self.new(util.shallow_copy_table(self.entries or {}), span)
 end
 
 function _M.with_span_context(self, span_context)

--- a/lib/opentelemetry/context.lua
+++ b/lib/opentelemetry/context.lua
@@ -116,7 +116,7 @@ function _M.extract_baggage(self)
 end
 
 function _M.with_span(self, span)
-    return self.new(self.current().entries, span)
+    return self.new(self.entries, span)
 end
 
 function _M.with_span_context(self, span_context)

--- a/lib/opentelemetry/context.lua
+++ b/lib/opentelemetry/context.lua
@@ -116,7 +116,7 @@ function _M.extract_baggage(self)
 end
 
 function _M.with_span(self, span)
-    return self.new({}, span)
+    return self.new(self.current().entries, span)
 end
 
 function _M.with_span_context(self, span_context)

--- a/lib/opentelemetry/context.lua
+++ b/lib/opentelemetry/context.lua
@@ -116,7 +116,7 @@ function _M.extract_baggage(self)
 end
 
 function _M.with_span(self, span)
-    return self.new(self.entries, span)
+    return self.new(self.entries or {}, span)
 end
 
 function _M.with_span_context(self, span_context)

--- a/spec/context_spec.lua
+++ b/spec/context_spec.lua
@@ -21,6 +21,27 @@ describe("current", function()
     end)
 end)
 
+describe("with_span", function()
+    it("pushes entries of current context onto new span context", function()
+        otel_global.set_context_storage({})
+        local original_entries = { foo = "bar"}
+        local ctx_1 = context.new(original_entries)
+        ctx_1:attach()
+        assert.are.equal(ctx_1, context.current())
+        local fake_span = "hi"
+        local ctx_2 = ctx_1:with_span(fake_span)
+        assert.are.same(ctx_2.entries, original_entries)
+    end)
+
+    it("handles absence of current context gracefully", function()
+        otel_global.set_context_storage({})
+        assert.are.same({}, context.current().entries)
+        local fake_span = "hi"
+        local ctx = context:with_span(fake_span)
+        assert.are.same(ctx.entries, {})
+    end)
+end)
+
 describe("attach", function()
     it("creates new table at context_key if no table present and returns token matching length of stack after adding element", function()
         local ctx_storage = {}

--- a/spec/context_spec.lua
+++ b/spec/context_spec.lua
@@ -22,20 +22,15 @@ describe("current", function()
 end)
 
 describe("with_span", function()
-    it("pushes entries of current context onto new span context", function()
+    it("sets supplied entries on new context", function()
         otel_global.set_context_storage({})
-        local original_entries = { foo = "bar"}
-        local ctx_1 = context.new(original_entries)
-        ctx_1:attach()
-        assert.are.equal(ctx_1, context.current())
-        local fake_span = "hi"
-        local ctx_2 = ctx_1:with_span(fake_span)
-        assert.are.same(ctx_2.entries, original_entries)
+        local original_entries = { foo = "bar" }
+        local old_ctx = context.new(original_entries, "oldspan")
+        local ctx = old_ctx:with_span("myspan")
+        assert.are.same(ctx.entries, original_entries)
     end)
 
-    it("handles absence of current context gracefully", function()
-        otel_global.set_context_storage({})
-        assert.are.same({}, context.current().entries)
+    it("handles absence of entries arg gracefully", function()
         local fake_span = "hi"
         local ctx = context:with_span(fake_span)
         assert.are.same(ctx.entries, {})


### PR DESCRIPTION
I found this bug when investigating why the Baggage Propagator was not working. The propagator extraction works fine, but when we  create new spans with `with_span`, we do not copy the parent context's entries, so when we `inject`, there's nothing there. This PR 