### PR TITLE
Speed up id generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: doc format api-test
+.PHONY: doc format api-test benchmark
 CONTAINER_ORCHESTRATOR ?= docker-compose
 CONTAINER_ORCHESTRATOR_EXEC_OPTIONS := $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS)
 
@@ -35,3 +35,6 @@ api-test:
 
 generate-semantic-conventions:
 	$(CONTAINER_ORCHESTRATOR) run --no-deps $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS) -- openresty bash -c 'pushd tmp && rm -rf opentelemetry-specification && git clone --depth=1 https://github.com/open-telemetry/opentelemetry-specification.git && popd && resty ./utils/generate_semantic_conventions.lua && lua-format -i lib/opentelemetry/semantic_conventions/trace/*.lua'
+
+benchmark:
+	$(CONTAINER_ORCHESTRATOR) run --no-deps $(CONTAINER_ORCHESTRATOR_EXEC_OPTIONS) -- openresty bash -c 'cd /opt/opentelemetry-lua && benchmark/run.sh'

--- a/README.md
+++ b/README.md
@@ -335,3 +335,7 @@ local my_metrics_reporter = {
 }
 otel_global.set_metrics_reporter(metrics_reporter)
 ```
+
+### Benchmarks
+
+You can run benchmarks using `make benchmark`.

--- a/benchmark/id_generator.lua
+++ b/benchmark/id_generator.lua
@@ -1,0 +1,8 @@
+local id_generator = require("lib.opentelemetry.trace.id_generator")
+local start = os.clock()
+
+for _ = 1, 5000000 do
+    id_generator.new_ids()
+end
+
+print('fewer random calls, 5m new ids: ' .. (os.clock() - start) ..' seconds.')

--- a/benchmark/id_generator.lua
+++ b/benchmark/id_generator.lua
@@ -5,4 +5,4 @@ for _ = 1, 5000000 do
     id_generator.new_ids()
 end
 
-print('fewer random calls, 5m new ids: ' .. (os.clock() - start) ..' seconds.')
+print('5m new ids: ' .. (os.clock() - start) ..' seconds.')

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+FILES="benchmark/*.lua"
+for f in $FILES
+do
+  if [ -f "$f" ]
+  then
+    resty -I /opt/opentelemetry-lua/lib "$f"
+  fi
+done

--- a/lib/opentelemetry/trace/exporter/console.lua
+++ b/lib/opentelemetry/trace/exporter/console.lua
@@ -29,7 +29,7 @@ function _M.export_spans(self, spans)
 
     -- Check if ngx variable is not nil; use ngx.log if ngx var is present.
     if ngx then
-        ngx.log(ngx.INFO, "Export spans: ", span_string)
+        ngx.log(ngx.CRIT, "Export spans: ", span_string)
     else
         print("Export spans: ", span_string)
     end

--- a/lib/opentelemetry/trace/exporter/console.lua
+++ b/lib/opentelemetry/trace/exporter/console.lua
@@ -29,7 +29,7 @@ function _M.export_spans(self, spans)
 
     -- Check if ngx variable is not nil; use ngx.log if ngx var is present.
     if ngx then
-        ngx.log(ngx.CRIT, "Export spans: ", span_string)
+        ngx.log(ngx.INFO, "Export spans: ", span_string)
     else
         print("Export spans: ", span_string)
     end

--- a/lib/opentelemetry/trace/id_generator.lua
+++ b/lib/opentelemetry/trace/id_generator.lua
@@ -4,39 +4,22 @@ local bit = require 'bit'
 local tohex = bit.tohex
 local fmt = string.format
 local random = util.random
+local FFFFFFFF = 4294967295 -- FFFFFFFF in hexadecimal is 4294967295 in decimal
 
 local _M = {}
 
 function _M.new_span_id()
-    return fmt("%s%s%s%s%s%s%s%s",
-                tohex(random(0, 255), 2),
-                tohex(random(0, 255), 2),
-                tohex(random(0, 255), 2),
-                tohex(random(0, 255), 2),
-                tohex(random(0, 255), 2),
-                tohex(random(0, 255), 2),
-                tohex(random(0, 255), 2),
-                tohex(random(0, 255), 2))
+    return fmt("%s%s",
+        tohex(random(0, FFFFFFFF), 8),
+        tohex(random(0, FFFFFFFF), 8))
 end
 
 function _M.new_ids()
-    return fmt("%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2),
-            tohex(random(0, 255), 2)), _M.new_span_id()
+    return fmt("%s%s%s%s",
+        tohex(random(0, FFFFFFFF), 8),
+        tohex(random(0, FFFFFFFF), 8),
+        tohex(random(0, FFFFFFFF), 8),
+        tohex(random(0, FFFFFFFF), 8)), _M.new_span_id()
 end
 
 return _M

--- a/lib/opentelemetry/trace/id_generator.lua
+++ b/lib/opentelemetry/trace/id_generator.lua
@@ -4,22 +4,21 @@ local bit = require 'bit'
 local tohex = bit.tohex
 local fmt = string.format
 local random = util.random
-local FFFFFFFF = 4294967295 -- FFFFFFFF in hexadecimal is 4294967295 in decimal
 
 local _M = {}
 
 function _M.new_span_id()
     return fmt("%s%s",
-        tohex(random(0, FFFFFFFF), 8),
-        tohex(random(0, FFFFFFFF), 8))
+        tohex(random(0, 0xFFFFFFFF), 8),
+        tohex(random(0, 0xFFFFFFFF), 8))
 end
 
 function _M.new_ids()
     return fmt("%s%s%s%s",
-        tohex(random(0, FFFFFFFF), 8),
-        tohex(random(0, FFFFFFFF), 8),
-        tohex(random(0, FFFFFFFF), 8),
-        tohex(random(0, FFFFFFFF), 8)), _M.new_span_id()
+        tohex(random(0, 0xFFFFFFFF), 8),
+        tohex(random(0, 0xFFFFFFFF), 8),
+        tohex(random(0, 0xFFFFFFFF), 8),
+        tohex(random(0, 0xFFFFFFFF), 8)), _M.new_span_id()
 end
 
 return _M

--- a/spec/trace/id_generator_spec.lua
+++ b/spec/trace/id_generator_spec.lua
@@ -1,0 +1,19 @@
+local id_generator = require("opentelemetry.trace.id_generator")
+
+describe("new_span_id", function()
+    it("generates a 16 character hex string", function()
+        for _ = 0, 100 do
+            assert.is_equal(16, #id_generator.new_span_id())
+        end
+    end)
+end)
+
+describe("new_ids", function()
+    it("generates a 16 character hex string and a 32 character string", function()
+        for _ = 0, 100 do
+            local trace_id, span_id = id_generator.new_ids()
+            assert.is_equal(32, #trace_id)
+            assert.is_equal(16, #span_id)
+        end
+    end)
+end)


### PR DESCRIPTION
**Background**

Older versions of Lua, such as 5.1 (which LuaJIT, and hence OpenResty, is compatible with) has trouble with really big numbers. This is why the repo's ID generator involves concatenating strings. I don't know the full details here, so please correct me if I'm missing something.

**Benchmarks**

### Before
`5m new ids: 10.136033 seconds.`

### After
`5m new ids: 0.118243 seconds.`

**Code Changes**

I investigated speeding ID generation up (it's a substantial portion of all CPU time), and I think that this makes it 92 times faster (woo). The existing code generates a random number between 0 and 255, which will generate a hexadecimal character between `00` and `ff`. For a span ID, it does this 8 times (resulting in a 16 character hexadecimal span ID); for a trace id, it does it 16 times (resulting in a 32 character hexadecimal trace id). See `bit.tohex` here: http://bitop.luajit.org/api.html.

This code change moves from generating a random number between `0` and `4294967295`, which is `FFFFFFFF` rendered as a decimal:
 
<img width="553" alt="image" src="https://user-images.githubusercontent.com/370182/231870794-d91df7a1-c433-488f-ab23-a493b40b5bf5.png">

**What to look for**

Are we still generating the full range of IDs? A cursory look suggest yes:

```
20393bcd168228a23cfe370dce47e29e
efc6a2911cc64d91
30fbc93b2d20a53dfdca0b5dc0783394
44b7ac08f82986d9
534cd7dd6a3583de52c5a4e294fa60ed
ae137d1e9ee516de
23f1e6467f793b43286a502f59d9e221
6f05e3965b2532ea
39141e3c83070fa1266e129fc098743e
5c56d44e74978487
ebc6b6dd1a0bafdde0a0fc6117c00b8b
23a22eb783b92fb5
d5b70f5c829b52e4c73e1a88d7804755
4ca8a96f4bc5ce9f
b03c2c0dea2828670e58106c0857bffb
b272d4dbe63da077
```
