### PR TITLE
Allow multiple Inst or resource for export

### DIFF
--- a/spec/trace/exporter/otlp_spec.lua
+++ b/spec/trace/exporter/otlp_spec.lua
@@ -2,7 +2,84 @@ local exporter = require "opentelemetry.trace.exporter.otlp"
 local client = require "opentelemetry.trace.exporter.http_client"
 local context = require "opentelemetry.context"
 local tp = Global.get_tracer_provider()
+local tracer_provider_new = require("opentelemetry.trace.tracer_provider").new
 local tracer = tp:tracer("test")
+
+describe("encode_spans", function()
+    it("one resource span and one ils for one span", function()
+        local span
+        local ctx = context.new()
+        ctx, span = tracer:start(ctx, "test span")
+        span:finish()
+        local cb = exporter.new(nil)
+        local encoded = cb:encode_spans({span, other_spans})
+        -- One resource, one il, one span
+        assert(#encoded.resource_spans == 1)
+        local resource = encoded.resource_spans[1]
+        assert(#resource.instrumentation_library_spans == 1)
+        assert(#resource.instrumentation_library_spans[1].spans == 1)
+    end)
+
+    it("one resource span and one ils for multiple span same tracer", function()
+        local span
+        local ctx = context.new()
+        local spans = {}
+        for i=10,1,-1 do
+            ctx, span = tracer:start(ctx, "test span" .. i)
+            span:finish()
+            table.insert(spans, span)
+        end
+        local cb = exporter.new(nil)
+        local encoded = cb:encode_spans(spans)
+        -- One resource, one il, 10 spans
+        assert(#encoded.resource_spans == 1)
+        local resource = encoded.resource_spans[1]
+        assert(#resource.instrumentation_library_spans == 1)
+        assert(#resource.instrumentation_library_spans[1].spans == 10)
+    end)
+
+    it("one resource span and two ils for spans from distinct tracers", function()
+        local span
+        local ctx = context.new()
+        local spans = {}
+        ctx, span = tracer:start(ctx, "test span")
+        span:finish()
+        table.insert(spans, span)
+        local other_tracer = tp:tracer("exam")
+        ctx, other_span = other_tracer:start(ctx, "exam span")
+        table.insert(spans, other_span)
+        local cb = exporter.new(nil)
+        local encoded = cb:encode_spans(spans)
+        -- One resource, two il, 1 span each
+        assert(#encoded.resource_spans == 1)
+        local resource = encoded.resource_spans[1]
+        assert(#resource.instrumentation_library_spans == 2)
+        assert(#resource.instrumentation_library_spans[1].spans == 1)
+        assert(#resource.instrumentation_library_spans[2].spans == 1)
+    end)
+    it("distinct trace providers provide distinct resources", function()
+        local span
+        local ctx = context.new()
+        local spans = {}
+        ctx, span = tracer:start(ctx, "test span")
+        span:finish()
+        table.insert(spans, span)
+        local op = tracer_provider_new(nil, nil)
+        local other_tracer = op:tracer("exam")
+        ctx, other_span = other_tracer:start(ctx, "exam span")
+        table.insert(spans, other_span)
+        local cb = exporter.new(nil)
+        local encoded = cb:encode_spans(spans)
+        -- two resources with one il, 1 span each
+        assert(#encoded.resource_spans == 2)
+        local resource = encoded.resource_spans[1]
+        assert(#resource.instrumentation_library_spans == 1)
+        assert(#resource.instrumentation_library_spans[1].spans == 1)
+        resource = encoded.resource_spans[2]
+        assert(#resource.instrumentation_library_spans == 1)
+        assert(#resource.instrumentation_library_spans[1].spans == 1)
+    end)
+end)
 
 describe("export_spans", function()
     it("invokes do_request when there are no failures", function()


### PR DESCRIPTION
* Currently if 2 tracer providers or 2 tracers are exporting, there is a first one in batch wins condition for exporting spans
* This change moves encoding the body into its own function, and adds unittests for spans from different tracers and from different trace providers to ensure resource and il parts of the otlp export are set properly